### PR TITLE
Add parameters for ERT db creds

### DIFF
--- a/ci/tasks/configure-json.yml
+++ b/ci/tasks/configure-json.yml
@@ -26,6 +26,8 @@ params:
   pcf_ert_ssl_key:
   terraform_template:
   terraform_prefix:
+  ert_sql_db_username:
+  ert_sql_db_password:
   # IaaS Specific for GCP only
   gcp_proj_id:
   gcp_region:

--- a/json_templates/gcp/c0-gcp-poc/ert-template.json
+++ b/json_templates/gcp/c0-gcp-poc/ert-template.json
@@ -52,10 +52,58 @@
       ".properties.system_database.external.host": {
         "value": "{{gcloud_sql_instance_ip}}"
       },
-      ".properties.system_database.external.username": {
+      ".properties.system_database.external.app_usage_service_username": {
         "value": "{{gcloud_sql_instance_username}}"
       },
-      ".properties.system_database.external.password": {
+      ".properties.system_database.external.app_usage_service_password": {
+        "value": {
+          "secret": "{{gcloud_sql_instance_password}}"
+        }
+      },
+      ".properties.system_database.external.autoscale_username": {
+        "value": "{{gcloud_sql_instance_username}}"
+      },
+      ".properties.system_database.external.autoscale_password": {
+        "value": {
+          "secret": "{{gcloud_sql_instance_password}}"
+        }
+      },
+      ".properties.system_database.external.ccdb_username": {
+        "value": "{{gcloud_sql_instance_username}}"
+      },
+      ".properties.system_database.external.ccdb_password": {
+        "value": {
+          "secret": "{{gcloud_sql_instance_password}}"
+        }
+      },
+      ".properties.system_database.external.diego_username": {
+        "value": "{{gcloud_sql_instance_username}}"
+      },
+      ".properties.system_database.external.diego_password": {
+        "value": {
+          "secret": "{{gcloud_sql_instance_password}}"
+        }
+      },
+      ".properties.system_database.external.notifications_username": {
+        "value": "{{gcloud_sql_instance_username}}"
+      },
+      ".properties.system_database.external.notifications_password": {
+        "value": {
+          "secret": "{{gcloud_sql_instance_password}}"
+        }
+      },
+      ".properties.system_database.external.routing_username": {
+        "value": "{{gcloud_sql_instance_username}}"
+      },
+      ".properties.system_database.external.routing_password": {
+        "value": {
+          "secret": "{{gcloud_sql_instance_password}}"
+        }
+      },
+      ".properties.system_database.external.uaa_username": {
+        "value": "{{gcloud_sql_instance_username}}"
+      },
+      ".properties.system_database.external.uaa_password": {
         "value": {
           "secret": "{{gcloud_sql_instance_password}}"
         }

--- a/scripts/iaas-specific-config/gcp/run.sh
+++ b/scripts/iaas-specific-config/gcp/run.sh
@@ -21,10 +21,10 @@ gcloud_sql_instance_cmd="gcloud sql instances list --format json | jq '.[] | sel
 gcloud_sql_instance=$(eval ${gcloud_sql_instance_cmd})
 gcloud_sql_instance_ip=$(gcloud sql instances list | grep ${gcloud_sql_instance} | awk '{print$4}')
 perl -pi -e "s/{{gcloud_sql_instance_ip}}/${gcloud_sql_instance_ip}/g" ${json_file}
-perl_cmd="perl -pi -e \"s/{{gcloud_sql_instance_username}}/${pcf_opsman_admin}/g\" ${json_file}"
+perl_cmd="perl -pi -e \"s/{{gcloud_sql_instance_username}}/${ert_sql_db_username}/g\" ${json_file}"
   perl_cmd=$(echo $perl_cmd | sed 's/\@/\\@/g')
   eval $perl_cmd
-perl_cmd="perl -pi -e \"s/{{gcloud_sql_instance_password}}/${pcf_opsman_admin_passwd}/g\" ${json_file}"
+perl_cmd="perl -pi -e \"s/{{gcloud_sql_instance_password}}/${ert_sql_db_password}/g\" ${json_file}"
   perl_cmd=$(echo $perl_cmd | sed 's/\@/\\@/g')
   eval $perl_cmd
 

--- a/scripts/iaas-specific-config/gcp/run.sh
+++ b/scripts/iaas-specific-config/gcp/run.sh
@@ -20,13 +20,10 @@ gcloud config set compute/region $gcp_region
 gcloud_sql_instance_cmd="gcloud sql instances list --format json | jq '.[] | select(.instance | startswith(\"${terraform_prefix}\")) | .instance' | tr -d '\"'"
 gcloud_sql_instance=$(eval ${gcloud_sql_instance_cmd})
 gcloud_sql_instance_ip=$(gcloud sql instances list | grep ${gcloud_sql_instance} | awk '{print$4}')
-perl -pi -e "s/{{gcloud_sql_instance_ip}}/${gcloud_sql_instance_ip}/g" ${json_file}
-perl_cmd="perl -pi -e \"s/{{gcloud_sql_instance_username}}/${ert_sql_db_username}/g\" ${json_file}"
-  perl_cmd=$(echo $perl_cmd | sed 's/\@/\\@/g')
-  eval $perl_cmd
-perl_cmd="perl -pi -e \"s/{{gcloud_sql_instance_password}}/${ert_sql_db_password}/g\" ${json_file}"
-  perl_cmd=$(echo $perl_cmd | sed 's/\@/\\@/g')
-  eval $perl_cmd
+
+sed -i -e 's/{{gcloud_sql_instance_ip}}/'"${gcloud_sql_instance_ip}"'/g' ${json_file}
+sed -i -e 's/{{gcloud_sql_instance_username}}/'"${ert_sql_db_username}"'/g' ${json_file}
+sed -i -e 's/{{gcloud_sql_instance_password}}/'"${ert_sql_db_password}"'/g' ${json_file}
 
 #############################################################
 # Set GCP Storage Setup for GCP Buckets                     #


### PR DESCRIPTION
This fixes an issue in GCP where if the opsman and ERT DB creds are different then the pipeline fails.